### PR TITLE
Support for full url in request object

### DIFF
--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -45,14 +45,18 @@ class Client implements ClientInterface
         $body = $request->getBody();
         $headers = $request->getHeaders();
         $query = empty($request->getQuery()) ? "" : "?".http_build_query($request->getQuery());
-        $rawBaseUrl = (string)$this->guzzleClient->getConfig("base_uri");
-        if(empty($rawBaseUrl)){
-            throw new RuntimeException("Base url is not provided!");
+        if($request->hasFullUrl()){
+            $uri = new Uri($request->getUrl());
+        } else {
+            $rawBaseUrl = (string)$this->guzzleClient->getConfig("base_uri");
+            if(empty($rawBaseUrl)){
+                throw new RuntimeException("Base url is not provided!");
+            }
+            // trimming is here to avoid issues with "/" - too much slashes or missing slashes.
+            $baseUrl = rtrim($rawBaseUrl, "/");
+            $url = "/".ltrim($request->getUrl(),'/');
+            $uri = new Uri($baseUrl . $url . $query);
         }
-        // trimming is here to avoid issues with "/" - too much slashes or missing slashes.
-        $baseUrl = rtrim($rawBaseUrl, "/");
-        $url = "/".ltrim($request->getUrl(),'/');
-        $uri = new Uri($baseUrl . $url . $query);
 
         return new GuzzleRequest($request->getType(), $uri, $headers, $body);
     }

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -44,21 +44,26 @@ class Client implements ClientInterface
     {
         $body = $request->getBody();
         $headers = $request->getHeaders();
-        $query = empty($request->getQuery()) ? "" : "?".http_build_query($request->getQuery());
-        if($request->hasFullUrl()){
-            $uri = new Uri($request->getUrl());
+        $uri = $this->createUri($request);
+
+        return new GuzzleRequest($request->getType(), $uri, $headers, $body);
+    }
+
+    public function createUri(Request $request): Uri
+    {
+        $query = empty($request->getQuery()) ? "" : "?" . http_build_query($request->getQuery());
+        if ($request->hasFullUrl()) {
+            return new Uri($request->getUrl() . $query);
         } else {
             $rawBaseUrl = (string)$this->guzzleClient->getConfig("base_uri");
-            if(empty($rawBaseUrl)){
+            if (empty($rawBaseUrl)) {
                 throw new RuntimeException("Base url is not provided!");
             }
             // trimming is here to avoid issues with "/" - too much slashes or missing slashes.
             $baseUrl = rtrim($rawBaseUrl, "/");
-            $url = "/".ltrim($request->getUrl(),'/');
-            $uri = new Uri($baseUrl . $url . $query);
+            $url = "/" . ltrim($request->getUrl(), '/');
+            return new Uri($baseUrl . $url . $query);
         }
-
-        return new GuzzleRequest($request->getType(), $uri, $headers, $body);
     }
 
     /**

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -49,6 +49,10 @@ class Client implements ClientInterface
         return new GuzzleRequest($request->getType(), $uri, $headers, $body);
     }
 
+    /**
+     * @param Request $request
+     * @return Uri
+     */
     public function createUri(Request $request): Uri
     {
         $query = empty($request->getQuery()) ? "" : "?" . http_build_query($request->getQuery());

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -2,6 +2,8 @@
 
 namespace Assertis\Http\Request;
 
+use GuzzleHttp\Psr7\Uri;
+
 /**
  * Interface for http requests
  *
@@ -25,6 +27,13 @@ class Request
      * @var string
      */
     private $url;
+
+    /**
+     * Url wrapped into PSR7 Uri object
+     *
+     * @var Uri
+     */
+    private $psr7url;
 
     /**
      * Body of request to send
@@ -66,6 +75,7 @@ class Request
     public function __construct($url, $body = '', array $query = [], $type = self::DEFAULT_TYPE, $headers = [])
     {
         $this->url = $url;
+        $this->psr7url = new Uri($this->url);
         $this->body = $body;
         $this->query = $query;
         $this->type = $type;
@@ -108,6 +118,16 @@ class Request
     public function getUrl()
     {
         return $this->url;
+    }
+
+    /**
+     * @return bool
+     *  true - when $this->getUri() like http://host.com/resource
+     *  false - when $this->getUri() like /resource/XYZ
+     */
+    public function hasFullUrl(): bool
+    {
+        return !empty($this->psr7url->getHost()) && !empty($this->psr7url->getScheme());
     }
 
     /**

--- a/tests/Assertis/Tests/Http/ClientTest.php
+++ b/tests/Assertis/Tests/Http/ClientTest.php
@@ -47,6 +47,18 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('/endpoint', $createdRequest->getUri()->getPath());
     }
 
+    public function testShouldCreateRequestWithFullUrlInRequest()
+    {
+        $request = new Request('http://sample.com/endpoint', '', [], Request::GET);
+        $createdRequest = $this->client->createRequest($request);
+        $this->assertEquals('', $createdRequest->getBody()->getContents());
+        $this->assertEquals('', urldecode((string)$createdRequest->getUri()->getQuery()));
+        $this->assertEquals('http', $createdRequest->getUri()->getScheme());
+        $this->assertEquals('sample.com', $createdRequest->getUri()->getHost());
+        $this->assertEquals('GET', $createdRequest->getMethod());
+        $this->assertEquals('/endpoint', $createdRequest->getUri()->getPath());
+    }
+
     public function testShouldCreateRequestWithQuery()
     {
         $query = [

--- a/tests/Assertis/Tests/Http/ClientTest.php
+++ b/tests/Assertis/Tests/Http/ClientTest.php
@@ -59,6 +59,25 @@ class ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('/endpoint', $createdRequest->getUri()->getPath());
     }
 
+    public function testShouldCreateRequestWithFullUrlInRequestAndQuery()
+    {
+        $query = [
+            'foo' => 'bar',
+            'test' => [
+                'x' => 'y'
+            ]
+        ];
+        $request = new Request('http://sample.com/endpoint', '', $query, Request::GET);
+
+        $createdRequest = $this->client->createRequest($request);
+        $this->assertEquals('', $createdRequest->getBody()->getContents());
+        $this->assertEquals('foo=bar&test[x]=y', urldecode((string)$createdRequest->getUri()->getQuery()));
+        $this->assertEquals('http', $createdRequest->getUri()->getScheme());
+        $this->assertEquals('sample.com', $createdRequest->getUri()->getHost());
+        $this->assertEquals('GET', $createdRequest->getMethod());
+        $this->assertEquals('/endpoint', $createdRequest->getUri()->getPath());
+    }
+
     public function testShouldCreateRequestWithQuery()
     {
         $query = [

--- a/tests/Assertis/Tests/Http/RequestTest.php
+++ b/tests/Assertis/Tests/Http/RequestTest.php
@@ -34,4 +34,29 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $request->setBody($newBody);
         $this->assertEquals($newBody, $request->getBody());
     }
+
+    public function hasFullUrlDataProvider()
+    {
+        return [
+            ['/resource/XYZ', false],
+            ['/', false],
+            ['/sampleendpoint', false],
+            ['host.com/endpoint', false],
+            ['http://host.com', true],
+            ['http://host.com/', true],
+            ['http://host.com/endpoint', true],
+            ['http://host.com/resource/XYZ', true],
+        ];
+    }
+
+    /**
+     * @dataProvider hasFullUrlDataProvider
+     * @param $url
+     * @param $expected
+     */
+    public function testHasFullUrl($url, $expected)
+    {
+        $request = new Request($url, '', []);
+        $this->assertEquals($expected, $request->hasFullUrl());
+    }
 }


### PR DESCRIPTION
why?
because during links resolving we do not want to have separate client for each possible service, we need single client able to resolve any received URI.